### PR TITLE
Use coredns/caddy to fix tests

### DIFF
--- a/records_test.go
+++ b/records_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
-	"github.com/caddyserver/caddy"
 	"github.com/miekg/dns"
 )
 


### PR DESCRIPTION
The tests fail:
```
$ go test ./...
# github.com/coredns/records [github.com/coredns/records.test]
./records_test.go:24:25: cannot use c (type *"github.com/caddyserver/caddy".Controller) as type *"github.com/coredns/caddy".Controller in argument to recordsParse
./records_test.go:83:25: cannot use c (type *"github.com/caddyserver/caddy".Controller) as type *"github.com/coredns/caddy".Controller in argument to recordsParse
./records_test.go:136:25: cannot use c (type *"github.com/caddyserver/caddy".Controller) as type *"github.com/coredns/caddy".Controller in argument to recordsParse
FAIL    github.com/coredns/records [build failed]
FAIL
```

Looks like there is inconsistency in using `caddy` in `recordsParse()`, use the stripped down `coredns/caddy` instead.